### PR TITLE
Add 'AC_PROG_CC_STDC' in configure.ac to solve compile error.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AM_INIT_AUTOMAKE([foreign dist-xz])
 LT_INIT
 
 AC_PROG_CC
+AC_PROG_CC_STDC
 
 AC_ARG_WITH([jvm],
             [AS_HELP_STRING([--with-jvm], [JAVA HOME PATH])],


### PR DESCRIPTION
I tried to compile this library on CentOS 7.4, but the following error occuerred.

```
unix-java.c:257:4: error: 'for' loop initial declarations are only allowed in C99 mode
    for (int i = 0, j = 0, s = 0; i <= els; i++, j++) {
    ^
unix-java.c:257:4: note: use option -std=c99 or -std=gnu99 to compile your code
```

This error is caused by the difference of C Langage Standard in gcc version.
Use `AC_PROG_CC_STDC` macro to avoid these error. 

>Macro: AC_PROG_CC_STDC
>
> If the C compiler cannot compile ISO Standard C (currently C99), try to add an option to output variable CC to make it work. If the compiler does not support C99, fall back to supporting ANSI C89 (ISO C90).

https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html

I added this macro to configure.ac and successfully compiled with CentOS 7.4(gcc 4.8.5) and Fedora 27(gcc 7.2.1).
